### PR TITLE
Fixed bug with OPTIMIZED-MAKER-NAME

### DIFF
--- a/src/common.lisp
+++ b/src/common.lisp
@@ -49,7 +49,7 @@
 ;;; These functions are named according to big-endian conventions.  The
 ;;; comment is here because I always forget and need to be reminded.
 #.(loop for i from 1 to 8
-        collect (let ((name (intern (format nil "~:R-~A" i '#:byte))))
+        collect (let ((name (read-from-string (format nil "~:R-~A" i '#:byte))))
                   `(progn
                     (declaim (inline ,name))
                     (declaim (ftype (function (unsigned-byte) (unsigned-byte 8)) ,name))


### PR DESCRIPTION
I've discovered that there's a bug in Ironclad when compiling my source
with _PRINT-CASE_ set to :downcase.  I tracked it down to
OPTIMIZED-MAKER-NAME, which doesn't call SYMBOL-NAME on the name it's
passed and just does a ~a to interpolate the name.  Here's an updated
version which does the right thing, whether it's passed a string or a
symbol.
