### PR TITLE
Fixed another case bug with ~:R

### DIFF
--- a/src/common.lisp
+++ b/src/common.lisp
@@ -98,7 +98,7 @@
                                                      (- bytes i)
                                                      (1- i))))
                                      `(setf (aref buffer (+ index ,offset))
-                                       (,(intern (format nil "~:R-~A" i '#:byte)) value))))
+                                       (,(read-from-string (format nil "~:R-~A" i '#:byte)) value))))
                    (values)))))
            (define-fetchers-and-storers (bitsize)
              `(progn


### PR DESCRIPTION
Found another instance in DEFINE-FETCHERS-AND-STORERS.

I wonder if the Right Thing is to have a function ASSEMBLE-SYMBOL which takes a list of strings, symbols, characters and numbers and returns a new symbol, with the 'right' case for the user's Lisp.  This would also mean that _PRINT-CASE_ could be left as-is when compiling.  Thoughts?

Here's a possible implementation:

(defun assemble-symbol (&rest things)
  (intern (format nil "~{~a~}"
          (mapcar (lambda (thing)
                (typecase thing
                  (string (symbol-name (read-from-string thing)))
                  (character
                   (symbol-name
                (read-from-string
                 (make-string 1 :initial-element thing))))
                  (symbol (symbol-name thing))
                  (t thing)))
              things))))

Usage:

(let ((bitsize 16) (big-endian-p t))
       (assemble-symbol '#:ub bitsize '#:ref #\/ (if big-endian-p '#:be '#:le)))
-> UB16REF/BE
