### PR TITLE
Fixed bug with OPTIMIZED-MAKER-NAME

### DIFF
--- a/src/digests/digest.lisp
+++ b/src/digests/digest.lisp
@@ -409,7 +409,10 @@ An error will be signaled if there is insufficient room in DIGEST."))
   (let ((*package* (find-package :ironclad)))
     ;; Ironclad gets compiled with *PRINT-CASE* set to :UPCASE; ensure
     ;; that names we return match what got compiled.n
-    (intern (format nil "%~A-~A-~A" '#:make name '#:digest))))
+    (intern (format nil "%~A-~A-~A"
+		    (symbol-name '#:make)
+		    (symbol-name name)
+		    (symbol-name '#:digest)))))
 
 (defmacro defdigest (name &key digest-length block-length)
   (let ((optimized-maker-name (optimized-maker-name name)))


### PR DESCRIPTION
I discovered that OPTIMIZED-MAKER-NAME breaks with `*PRINT-CASE* :LOWER` in the following circumstance:
1. load Ironclad
2. ''''(let ((_print-case_ :lower)) (load CODE)''''

Where CODE is a file which calls IRONCLAD:DIGEST-SEQUENCE or friends.  It appears the the compile-macro for MAKE-DIGEST gets called with the lower-case print-case, which leads it to compile-in lower-case names.

By switching to use of SYMBOL-NAME, we should do the Right Thing regardless of print-case, read-case or Allegro modern mode.

Only tested on SBCL/Linux.
