### PR TITLE
Fix a bug on win32

### DIFF
--- a/src/prng/prng.lisp
+++ b/src/prng/prng.lisp
@@ -80,7 +80,7 @@ replacement for COMMON-LISP:RANDOM."
             (assert (>= (read-sequence seq seed-file) num-bytes))
             seq))
   ;; FIXME: this is _untested_!
-  #+(and win32 sb-dynamic-core)(sb!win32:crypt-gen-random num-bytes)
+  #+(and win32 sb-dynamic-core)(sb-win32:crypt-gen-random num-bytes)
   #-(or unix (and win32 sb-dynamic-core))(error "OS-RANDOM-SEED is not supported on your platform."))
 
 (defun read-os-random-seed (source &optional (prng *prng*))


### PR DESCRIPTION
I think there is a typo in prng.lisp.

"sb!win32" does not designate a package. I 've changed it to "sb-win32" and it works on my Windows 7 platform (amd64, sbcl 1.0.55).

Hope this helps!
