### PR TITLE
Scrypt

### DIFF
--- a/doc/ironclad-doc.txt
+++ b/doc/ironclad-doc.txt
@@ -427,25 +427,34 @@ insufficient space in " 'buffer' ".")
 
 ((:h2 id "kdfs") "Key derivation functions")
 
+(:p "Ironclad comes with the basic PBKDF1 and PBKDF2 algorithms, as well as
+an implementation of the scrypt key derivation function as defined by 
+Colin Percival's " (:url
+"http://www.tarsnap.com/scrypt.html"
+"The scrypt key derivation function."))
+
 (:describe :function (ironclad:derive-key digest))
 
-(:p "Given a key derivation function object (produced by " `make-kdf`
- or `make-scrypt-kdf`"), a password and salt (both must be of type " `(SIMPLE-ARRAY
+(:p "Given a key derivation function object (produced by " `make-kdf` "),
+ a password and salt (both must be of type " `(SIMPLE-ARRAY
 (UNSIGNED-BYTE 8) (*))` "), and number of digest iterations, returns
 the password digest as a byte array of length " 'key-length' ".")
 
-(:p "Scrypt ignores " 'iteration-count' "parameter.")
-
-(:h3 "PBKDF")
-
-(:p "Ironclad comes with the basic PBKDF1 and PBKDF2 algorithms, as
-well as convenience functions for using them to store passwords.")
+(:p "Scrypt ignores " 'iteration-count' " parameter.")
 
 (:describe :function (ironclad:make-kdf kdf))
 
 (:p "Returns a key derivation function instance (" 'kind' " must
-either be " 'pbkdf1' " or " 'pbkdf2' ") that uses the given "
-'digest' ".")
+either be " 'pbkdf1' ", " 'pbkdf2' " or " 'scrypt-kdf' "). The PBKDF
+algorithms use " 'digest' ". The scrypt key derivation uses cost parameters "
+'N' ", " 'r' " and " 'p' " (" 'N' " is a CPU cost parameter that must be a 
+power of 2, " 'r' " and " 'p' " are memory cost parameters that must be defined
+such that " 'r' " * " 'p' " <= 2^30.)")
+
+(:h3 "PBKDF Convenience functions")
+
+(:p "Ironclad comes with well as convenience functions for using 
+ PBKDF1 and PBKDF2 to store passwords.")
 
 (:describe :function (ironclad:pbkdf2-hash-password password))
 
@@ -464,15 +473,6 @@ that encodes the given salt and PBKDF2 algorithm parameters.")
 (:p "Given a " 'password' " byte vector and a combined salt and digest string
 produced by " `pbkdf2-hash-password-to-combined-string` ", checks whether
 the password is valid.")
-
-(:h3 "Scrypt")
-
-(:p "Ironclad comes with and implementation of the scrypt key
-derivation function as defined by Colin Percival's " (:url
-"http://www.tarsnap.com/scrypt.html"
-"The scrypt key derivation function."))
-
-(:describe :function (ironclad:make-scrypt-kdf kdf))
 
 (:p "Returns an scrypt key derivation function instance.")
 

--- a/ironclad.asd
+++ b/ironclad.asd
@@ -48,8 +48,9 @@
                          #+(or lispworks sbcl openmcl cmu allegro)
                          (:file "octet-stream" :depends-on ("common"))
                          (:file "padding" :depends-on ("common"))
-                         (:file "pkcs5" :depends-on ("common"))
-                         (:file "scrypt" :depends-on ("pkcs5"))
+                         (:file "kdf-common" :depends-on ("package"))
+                         (:file "pkcs5" :depends-on ("common" "kdf-common"))
+                         (:file "scrypt" :depends-on ("kdf-common" "pkcs5"))
                          (:file "password-hash" :depends-on ("pkcs5"))
                          (:file "math" :depends-on ("prng" "public-key"))
                          (:module "sbcl-opt"

--- a/src/conditions.lisp
+++ b/src/conditions.lisp
@@ -69,7 +69,7 @@ for a particular mode of operation but not supplied."))
    (r :initarg :r :reader cost-r)
    (p :initarg :p :reader cost-p))
   (:report (lambda (condition stream)
-             (format stream "Scrypt cost factors not supported. N=~A must be a power of two and (r=~A * p=~A) <= 2 power of 30."
+             (format stream "Scrypt cost factors not supported. N=~A must be a power of two and (r=~A * p=~A) <= 2^30."
                      (cost-N condition) (cost-r condition) (cost-p condition))))
   (:documentation "Signaled when a invalid cost factors are provided to MAKE-SCRYPT-KDF."))
 

--- a/src/kdf-common.lisp
+++ b/src/kdf-common.lisp
@@ -1,0 +1,37 @@
+;;;; -*- mode: lisp; indent-tabs-mode: nil -*-
+(in-package :crypto)
+
+(defgeneric derive-key (kdf passphrase salt iteration-count key-length))
+
+(defclass pbkdf1 ()
+  ((digest :reader kdf-digest)))
+
+(defclass pbkdf2 ()
+  ((digest-name :initarg :digest :reader kdf-digest)))
+
+(defclass scrypt-kdf ()
+ ((N :initarg :N :reader scrypt-kdf-N)
+  (r :initarg :r :reader scrypt-kdf-r)
+  (p :initarg :p :reader scrypt-kdf-p)))
+
+(defun make-kdf (kind &key digest (N 16384) (r 8) (p 1))
+  ;; PBKDF1, at least, will do stricter checking; this is good enough for now.
+  "digest is used for pbkdf1 and pbkdf2.
+   N, p, and r are cost factors for scrypt."
+  (case kind
+    (pbkdf1
+     (unless (digestp digest)
+       (error 'unsupported-digest :name digest))
+     (make-instance 'pbkdf1 :digest digest))
+    (pbkdf2
+     (unless (digestp digest)
+       (error 'unsupported-digest :name digest))
+     (make-instance 'pbkdf2 :digest digest))
+    (scrypt-kdf
+     (when (or (<= N 1)
+               (not (zerop (logand N (1- N))))
+               (>= (* r p) (expt 2 30)))
+       (error 'unsupported-scrypt-cost-factors :N N :r r :p p))
+     (make-instance 'scrypt-kdf :N N :r r :p p))
+    (t
+     (error 'unsupported-kdf :kdf kind))))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -33,8 +33,8 @@
    #:ecb #:cbc #:ctr #:ofb #:cfb #:stream
 
    ;; KDFs
-   #:pbkdf1 #:pbkdf2 #:scryptkdf
-   #:make-kdf #:make-scrypt-kdf #:derive-key
+   #:pbkdf1 #:pbkdf2 #:scrypt-kdf
+   #:make-kdf #:derive-key
 
    ;; KDF convenience functions
    #:make-random-salt #:pbkdf2-hash-password

--- a/src/pkcs5.lisp
+++ b/src/pkcs5.lisp
@@ -1,13 +1,8 @@
 ;;;; -*- mode: lisp; indent-tabs-mode: nil -*-
 (in-package :crypto)
 
-(defgeneric derive-key (kdf passphrase salt iteration-count key-length))
-
 
 ;;; PBKDF1 from RFC 2898, section 5.1
-
-(defclass pbkdf1 ()
-  ((digest :reader kdf-digest)))
 
 (defmethod shared-initialize :after ((kdf pbkdf1) slot-names &rest initargs
                                      &key digest &allow-other-keys)
@@ -53,9 +48,6 @@
 
 ;;; PBKDF2, from RFC 2898, section 5.2
 
-(defclass pbkdf2 ()
-  ((digest-name :initarg :digest :reader kdf-digest)))
-
 (defun pbkdf2-derive-key (digest passphrase salt iteration-count key-length)
   (unless (plusp iteration-count)
     (error 'invalid-argument))
@@ -91,15 +83,3 @@
 
 (defmethod derive-key ((kdf pbkdf2) passphrase salt iteration-count key-length)
   (pbkdf2-derive-key (kdf-digest kdf) passphrase salt iteration-count key-length))
-
-(defun make-kdf (kind &key digest)
-  ;; PBKDF1, at least, will do stricter checking; this is good enough for now.
-  (unless (digestp digest)
-    (error 'unsupported-digest :name digest))
-  (case kind
-    (pbkdf1
-     (make-instance 'pbkdf1 :digest digest))
-    (pbkdf2
-     (make-instance 'pbkdf2 :digest digest))
-    (t
-     (error 'unsupported-kdf :kdf kind))))

--- a/src/scrypt.lisp
+++ b/src/scrypt.lisp
@@ -7,17 +7,6 @@
 ;;; presented at BSDCan'09, May 2009.
 ;;; http://www.tarsnap.com/scrypt.html
 
-(defclass scryptkdf ()
- ((N :accessor scrypt-kdf-N
-     :initarg :N
-     :initform 16384)
-  (r :accessor scrypt-kdf-r
-     :initarg :r
-     :initform 8)
-  (p :accessor scrypt-kdf-p
-     :initarg :p
-     :initform 1)))
-
 (defmacro salsa-vector-4mix (x i4 i8 i12 i0)
   `(setf (aref ,x ,i4) (ldb (byte 32 0) (logxor (aref ,x ,i4) (rol32 (mod32+ (aref ,x ,i0) (aref ,x ,i12)) 7)))
          (aref ,x ,i8) (ldb (byte 32 0) (logxor (aref ,x ,i8) (rol32 (mod32+ (aref ,x ,i4) (aref ,x ,i0)) 9)))
@@ -28,6 +17,7 @@
  (let ((x (make-array 16 :element-type '(unsigned-byte 32)))
        (w (make-array 16 :element-type '(unsigned-byte 32))))
   (declare (type (simple-array (unsigned-byte 32) (16)) x w))
+  (declare (dynamic-extent x w))
   (fill-block-ub8-le x b 0)
   (replace w x)
 
@@ -46,6 +36,8 @@
 
 (defun block-mix (b xy xy-start r)
  (let ((xs (make-array 64 :element-type '(unsigned-byte 8))))
+  (declare (type (simple-array (unsigned-byte 8) (64)) x w))
+  (declare (dynamic-extent x w))
   (replace xs b :start2 (* 64 (1- (* 2 r))) :end1 64)
   (dotimes (i (* 2 r))
     (xor-block 64 xs b (* i 64) xs 0)
@@ -58,35 +50,25 @@
 
 (defun smix (b b-start r N v xy)
  (let ((x xy)
-       (xy-start (* 128 r)))
-  (replace x b :end1 (* 128 r) :start2 b-start)
+       (xy-start (* 128 r))
+       (smix-length (* 128 r)))
+  (replace x b :end1 smix-length :start2 b-start)
   (dotimes (i N)
-    (replace v x :start1 (* i 128 r) :end2 (* 128 r))
+    (replace v x :start1 (* i smix-length) :end2 smix-length)
     (block-mix x xy xy-start r))
   (dotimes (i N)
     (let ((j (ldb (byte 32 0) (logand (nibbles:ub64ref/le x (* (1- (* 2 r)) 64)) (1- N)))))
-      (xor-block (* 128 r) x v (* j 128 r) x 0)
+      (xor-block smix-length x v (* j smix-length) x 0)
       (block-mix x xy xy-start r)))
-  (replace b x :start1 b-start :end1 (+ b-start (* 128 r)))))
+  (replace b x :start1 b-start :end1 (+ b-start smix-length))))
 
-(defmethod derive-key ((kdf scryptkdf) passphrase salt iteration-count key-length)
+(defmethod derive-key ((kdf scrypt-kdf) passphrase salt iteration-count key-length)
  (declare (ignore iteration-count))
- (let ((xy (make-array (* 256 (scrypt-kdf-r kdf)) :element-type '(unsigned-byte 8)))
-       (v (make-array (* 128 (scrypt-kdf-r kdf) (scrypt-kdf-N kdf)) :element-type '(unsigned-byte 8)))
-       (b (derive-key (make-kdf 'PBKDF2 :digest 'SHA256) passphrase salt 1 (* (scrypt-kdf-p kdf) 128 (scrypt-kdf-r kdf)))))
+ (let* ((pb-kdf (make-kdf 'PBKDF2 :digest 'SHA256))
+        (xy (make-array (* 256 (scrypt-kdf-r kdf)) :element-type '(unsigned-byte 8)))
+        (v (make-array (* 128 (scrypt-kdf-r kdf) (scrypt-kdf-N kdf)) :element-type '(unsigned-byte 8)))
+        (b (derive-key pb-kdf passphrase salt 1 (* (scrypt-kdf-p kdf) 128 (scrypt-kdf-r kdf)))))
   (dotimes (i (scrypt-kdf-p kdf))
     (smix b (* i 128 (scrypt-kdf-r kdf)) (scrypt-kdf-r kdf) (scrypt-kdf-N kdf) v xy))
-  (derive-key (make-kdf 'PBKDF2 :digest 'SHA256) passphrase b 1 key-length)))
-
-(defun make-scrypt-kdf (&optional (N 16384 N-supplied-p) (r 8 r-supplied-p) (p 1 p-supplied-p))
- "N is a CPU/memory cost parameter, and must be a power of two greater than 1.
- r and p must satisfy (< (* r p) (expt 2 30)). If the parameters do not satisfy
- the limits, that results in an unsupported-scrypt-costs error condition.
-
- The recommended paramters for interactive logins as of 2009 are:
- N=16384, r=8, p=1. They should be increased as memory latency and CPU parallelism
- increases."
-  (when (or (and N-supplied-p (or (<= N 1) (not (zerop (logand N (1- N))))))
-            (and (or r-supplied-p p-supplied-p) (>= (* r p) (expt 2 30))))
-    (error 'unsupported-scrypt-cost-factors :N N :r r :p p))
-  (make-instance 'scryptkdf :N N :r r :p p))
+  (reinitialize-instance pb-kdf :digest 'SHA256)
+  (derive-key pb-kdf passphrase b 1 key-length)))

--- a/testing/test-vectors/scrypt.lisp
+++ b/testing/test-vectors/scrypt.lisp
@@ -17,7 +17,7 @@
           '(vector (unsigned-byte 8))))
 
 (rtest:deftest scryptkdf1
-    (run-kdf-test (crypto:make-scrypt-kdf)
+    (run-kdf-test (crypto:make-kdf 'crypto:scrypt-kdf :N 16384 :r 8 :p 1)
                   *scrypt1-password* *scrypt1-salt* 1000 (length *scrypt1-key*) *scrypt1-key*)
   t)
 
@@ -34,7 +34,7 @@
           '(vector (unsigned-byte 8))))
 
 (rtest:deftest scryptkdf2
-    (run-kdf-test (crypto:make-scrypt-kdf 16384 8 2)
+    (run-kdf-test (crypto:make-kdf 'crypto:scrypt-kdf :N 16384 :r 8 :p 2)
                   *scrypt2-password* *scrypt2-salt* 1000 (length *scrypt2-key*) *scrypt2-key*)
   t)
 
@@ -51,6 +51,6 @@
           '(vector (unsigned-byte 8))))
 
 (rtest:deftest scryptkdf3
-    (run-kdf-test (crypto:make-scrypt-kdf 16 100 100)
+    (run-kdf-test (crypto:make-kdf 'crypto:scrypt-kdf :N 16 :r 100 :p 100)
                   *scrypt3-password* *scrypt3-salt* 1000 (length *scrypt3-key*) *scrypt3-key*)
   t)


### PR DESCRIPTION
Hi,

I'm not sure if you're interested in adding scrypt key derivation to ironclad, but if you are, here are the changes to add it.

scrypt information: http://www.tarsnap.com/scrypt.html

A couple (possible) issues:
1. I'm using the same derive-key generic function signature as used for PBKDF (and ignoring iteration-count), but not the same make-kdf function. The scrypt implementation in C assumes SHA256 and has it's own cost factors than can be supplied (N r p). I have created a new make-scrypt-kdf. This may need to be changed to either make it consistent with the PBKDF functions, or perhaps differentiated from them.
2. The changes I made to documentation may not be the best for the overall flow. I also do not know how you generate the html, so that is not in the patch.

Please let me know if there are things you'd like me to change.
