### PR TITLE
Corrected DSA-KEY group parameter accessors

### DIFF
--- a/src/public-key/dsa.lisp
+++ b/src/public-key/dsa.lisp
@@ -26,11 +26,11 @@
    (s :initarg :s :reader dsa-signature-s)))
 
 (defun dsa-key-p (dsa-key)
-  (slot-value (group dsa-key) 'group-p))
+  (group-pval (group dsa-key)))
 (defun dsa-key-q (dsa-key)
-  (slot-value (group dsa-key) 'group-q))
+  (group-qval (group dsa-key)))
 (defun dsa-key-g (dsa-key)
-  (slot-value (group dsa-key) 'group-g))
+  (group-gval (group dsa-key)))
 
 
 ;;; function definitions


### PR DESCRIPTION
The accessors DSA-KEY-P, DSA-KEY-Q, and DSA-KEY-G were using
slot-value names which are not the names of the slots any longer.
Switched these to use the READERs defined on the group slots.
