### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: common-lisp
+sudo: required
+
+env:
+  matrix:
+    - LISP=sbcl
+    - LISP=ccl
+    - LISP=clisp
+    - LISP=allegro
+
+install:
+  # Install cl-travis
+  - curl https://raw.githubusercontent.com/luismbo/cl-travis/master/install.sh | bash
+
+script:
+  - cl -l ironclad -l ironclad-tests
+       -e '(setf *debugger-hook*
+                 (lambda (c h)
+                   (declare (ignore c h))
+                   (uiop:quit -1)))'
+       -e '(rt:do-tests)'


### PR DESCRIPTION
This PR adds a `.travis.yml` file so you can test the library in the cloud with [Travis](travis-ci.org). Ironclad is tested on SBCL, CCL, CLISP and AllegroCL on commits and pull requests.

I didn't test on ABCL since the tests of the scrypt key derivation function took far too long.