### PR TITLE
fix dependency of salsa20.lisp on fndb.lisp

### DIFF
--- a/ironclad.asd
+++ b/ironclad.asd
@@ -56,7 +56,7 @@
                                   ((:file "fndb")
                                    (:file "x86oid-vm" :depends-on ("fndb"))))
                          (:module "ciphers"
-                                  :depends-on ("common" "macro-utils")
+                                  :depends-on ("common" "macro-utils" "sbcl-opt")
                                   :components
                                   (
                                    ;; block ciphers of various kinds


### PR DESCRIPTION
On certain SBCL versions, ``salsa-core`` in salsa20.lisp calls ``x-salsa-core`` which is only defined after fndb.lisp has been loaded.