### PR TITLE
fix type checking of stream element-type

### DIFF
--- a/src/digests/digest.lisp
+++ b/src/digests/digest.lisp
@@ -14,9 +14,7 @@
 
 (defun update-digest-from-stream (digest stream &key buffer (start 0) end)
   (cond
-    ((let ((element-type (stream-element-type stream)))
-       (or (equal element-type '(unsigned-byte 8))
-           (equal element-type '(integer 0 255))))
+    ((subtypep (stream-element-type stream) '(unsigned-byte 8))
      (flet ((frob (read-buffer start end)
               (loop for last-updated = (read-sequence read-buffer stream
                                                       :start start :end end)


### PR DESCRIPTION
Fixes the following use case:
```common-lisp
(ironclad:digest-stream :md5 (flexi-streams:make-in-memory-input-stream #(1 2 3)))
```

```
Unsupported stream element-type FLEXI-STREAMS:OCTET for stream #<FLEXI-STREAMS::VECTOR-INPUT-STREAM #x302119FBE6AD>.
   [Condition of type SIMPLE-ERROR]

Restarts:
 0: [RETRY] Retry SLIME interactive evaluation request.
 1: [*ABORT] Return to SLIME's top level.
 2: [ABORT-BREAK] Reset this thread
 3: [ABORT] Kill this thread

Backtrace:
  0: (IRONCLAD::UPDATE-DIGEST-FROM-STREAM #S(IRONCLAD:MD5 :AMOUNT 0 :BUFFER #(0 0 0 0 0 0 ...) :BUFFER-INDEX ...) #<FLEXI-STREAMS::VECTOR-INPUT-STREAM #x302119FBE6AD> :BUFFER NIL :START 0 :END NIL)
  1: (#<STANDARD-METHOD IRONCLAD:DIGEST-STREAM (T T)> #S(IRONCLAD:MD5 :AMOUNT 0 :BUFFER #(0 0 0 0 0 0 ...) :BUFFER-INDEX ...) #<FLEXI-STREAMS::VECTOR-INPUT-STREAM #x302119FBE6AD> :BUFFER NIL :START 0 :END ..
```