### PR TITLE
Key pair generation is unbearably slow because of using safe primes

### DIFF
--- a/src/public-key/dsa.lisp
+++ b/src/public-key/dsa.lisp
@@ -47,7 +47,7 @@
                   ((<= num-bits 7680) 384)
                   ((<= num-bits 15360) 512)
                   (t (error "This DSA key is too big"))))
-         (q (generate-safe-prime n prng))
+         (q (generate-prime n prng))
          (p (loop
                for z = (logior (ash 1 (- num-bits n 1))
                                (random-bits (- num-bits n) prng))

--- a/src/public-key/rsa.lisp
+++ b/src/public-key/rsa.lisp
@@ -35,8 +35,8 @@
          (l (floor num-bits 2))
          p q n)
     (loop
-       for a = (generate-safe-prime (- num-bits l) prng)
-       for b = (generate-safe-prime l prng)
+       for a = (generate-prime (- num-bits l) prng)
+       for b = (generate-prime l prng)
        for c = (* a b)
        until (and (/= a b) (= num-bits (integer-length c)))
        finally (setf p a


### PR DESCRIPTION
(Same as #91 except from another branch)

Perhaps using safe primes is a safe way to do it, however, I suppose it could be optional since it's pretty slow.

It's not the requirement for RSA cryptosystem and OpenSSL seems not to use them. Golang's (official) crypto library was using them at first, but [not anymore](https://groups.google.com/forum/#!topic/golang-dev/z6AccuSq1Gw).

## How slow

### Before (with safe primes)

Generating RSA 2048 bit key pairs took about 14 minutes on my MacBook Pro.

```
> (time (ironclad:generate-key-pair :rsa :num-bits 2048))
Evaluation took:
  830.441 seconds of real time
  813.642070 seconds of total run time (796.789971 user, 16.852099 system)
  [ Run times consist of 76.808 seconds GC time, and 736.835 seconds non-GC time. ]
  97.98% CPU
  2,485,737,524,086 processor cycles
  393,185,151,616 bytes consed
  
#<IRONCLAD::RSA-PRIVATE-KEY {1004F2E783}>
#<IRONCLAD::RSA-PUBLIC-KEY {1004F2F443}>
```

I assume RSA 2048 bit is the common example for RSA, since it's current recommended length by NIST and OpenSSL adopts it as the default.

### After (without safe primes)

It took only 1.8 seconds without safe primes.

```
> (time (ironclad:generate-key-pair :rsa :num-bits 2048))
Evaluation took:
  1.806 seconds of real time
  1.713652 seconds of total run time (1.588046 user, 0.125606 system)
  [ Run times consist of 0.192 seconds GC time, and 1.522 seconds non-GC time. ]
  94.91% CPU
  28 lambdas converted
  5,406,533,259 processor cycles
  87 page faults
  804,154,208 bytes consed
  
#<IRONCLAD::RSA-PRIVATE-KEY {1006A71F23}>
#<IRONCLAD::RSA-PUBLIC-KEY {1006B69F23}>
```