### PR TITLE
Fix RSA signature verification

### DIFF
--- a/src/public-key/rsa.lisp
+++ b/src/public-key/rsa.lisp
@@ -95,5 +95,6 @@
                                     :n-bits nbits)))
           (pss-verify :sha1 (subseq msg start end) s))
         (let ((s (integer-to-octets (rsa-core (octets-to-integer signature)
-                                              (rsa-key-exponent key) (rsa-key-modulus key)))))
+                                              (rsa-key-exponent key) (rsa-key-modulus key))
+                                    :n-bits (* (- (or end (length msg)) start) 8))))
           (equalp s (subseq msg start end))))))

--- a/src/public-key/rsa.lisp
+++ b/src/public-key/rsa.lisp
@@ -87,8 +87,6 @@
 
 (defmethod verify-signature ((key rsa-public-key) msg signature &key (start 0) end pss &allow-other-keys)
   (let ((nbits (integer-length (rsa-key-modulus key))))
-    (unless (= (* 8 (length signature)) nbits)
-      (error "Bad signature length"))
     (if pss
         (let ((s (integer-to-octets (rsa-core (octets-to-integer signature)
                                               (rsa-key-exponent key) (rsa-key-modulus key))


### PR DESCRIPTION
It's okay only for verifying signatures which is generated by Ironclad itself. Would be better if it works even for other language world's signatures.